### PR TITLE
Fix Next.js build by wrapping sonner toaster in client component

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { Inter } from "next/font/google";
-import { Toaster } from "sonner";
+import { Toaster } from "@/components/ui/sonner";
 import { Navbar } from "@/components/navbar";
 import { Footer } from "@/components/footer";
 

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { Toaster as SonnerToaster } from "sonner";
+import type { ToasterProps } from "sonner";
+
+export function Toaster(props: ToasterProps) {
+  return <SonnerToaster {...props} />;
+}


### PR DESCRIPTION
## Summary
- wrap the sonner toaster in a dedicated client component so it can be consumed from the server layout
- update the root layout to import the new wrapper instead of the library export directly

## Testing
- not run (npm install fails in this environment due to proxy restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68db65ebc76483339477af19c6735cb9