### PR TITLE
Fix path alias configuration for menu data imports

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,10 @@
         "name": "next"
       }
     ],
-    "baseUrl": "."
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
## Summary
- add an `@/*` path alias to TypeScript configuration so imports from `@/data/menuData` resolve

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db68dd51e48333b67e8bfabebb0d0b