### PR TITLE
Update Tailwind palette configuration

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -49,6 +49,6 @@ select:focus-visible {
     @apply bg-card rounded-3xl shadow-brass;
   }
   .badge-pill {
-    @apply inline-flex items-center rounded-full border border-muted/60 bg-card px-3 py-1 text-xs font-medium text-ink/80;
+    @apply inline-flex items-center rounded-full border border-muted-60 bg-card px-3 py-1 text-xs font-medium text-ink/80;
   }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,22 +3,24 @@ import type { Config } from "tailwindcss";
 const config: Config = {
   darkMode: ["class"],
   content: [
-    "./pages/**/*.{ts,tsx}",
-    "./components/**/*.{ts,tsx}",
-    "./app/**/*.{ts,tsx}"
+    "./app/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}"
   ],
   theme: {
     extend: {
       colors: {
-        primary: "var(--color-primary)",
-        accent: "var(--color-accent)",
-        ink: "var(--color-ink)",
-        surface: "var(--color-surface)",
-        card: "var(--color-card)",
-        muted: "var(--color-muted)",
-        success: "var(--color-success)",
-        warning: "var(--color-warning)",
-        danger: "var(--color-danger)"
+        primary: "#B88A2D",
+        accent: "#2E7F6E",
+        ink: "#0B1320",
+        surface: "#F7F5F0",
+        card: "#FFFFFF",
+        muted: {
+          DEFAULT: "#ECE8DD",
+          60: "#ECE8DD99"
+        },
+        success: "#1F8A5B",
+        warning: "#E0A100",
+        danger: "#D64545"
       },
       fontFamily: {
         sans: ["var(--font-inter)", "system-ui", "sans-serif"]


### PR DESCRIPTION
## Summary
- bake the Atelier Twenty Seven color palette directly into Tailwind with hex values and muted transparency support
- adjust Tailwind content globs to cover JavaScript and TypeScript files in app and component directories
- update the badge utility class to use the new muted border token supported by Tailwind

## Testing
- npm run lint *(fails: next not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db6a5fb03c8333a369c691c44d07b2